### PR TITLE
Update the PMIC config to disable battery charging

### DIFF
--- a/board/miovision/royaloak-ctm/royaloak-ctm.c
+++ b/board/miovision/royaloak-ctm/royaloak-ctm.c
@@ -16,6 +16,8 @@
 
 #define ETH_ALEN 6
 
+#define MAX77620_REG_CNFGBBC			0x04
+
 #include "pinmux-config-royaloak-ctm.h"
 
 /*
@@ -71,6 +73,22 @@ void pin_mux_mmc(void)
 		if (ret)
 			printf("i2c_write 0 0x3c 0x00 failed: %d\n", ret);
 	}
+
+	/* Disable Battery Backup Charging */
+	ret = dm_i2c_read(dev, MAX77620_REG_CNFGBBC, &val, 1);
+	if (ret) {
+		printf("i2c_read 0 0x3c 0x04 failed: %d\n", ret);
+	} else {
+		val &= ~BIT(0); /* Battery Backup Enable/Disable */
+		ret = dm_i2c_write(dev, MAX77620_REG_CNFGBBC, &val, 1);
+		if (ret) {
+			printf("i2c_write 0 0x3c 0x04 failed: %d\n", ret);
+		}
+		else {
+			printf("\nBackup battery charging support disabled\n");
+		}
+	}
+
 }
 
 #ifdef CONFIG_PCI_TEGRA


### PR DESCRIPTION
We are using a non-rechargeable coin cell on the CTM, this prevents the PMIC from trying to charge it.